### PR TITLE
Fix solid-slider typings in exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "types": "dist/index/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index/index.d.ts",
       "solid": "./dist/index/index.jsx",
       "import": "./dist/index/index.module.js",
       "browser": "./dist/index/index.module.js",
@@ -29,6 +30,7 @@
       "node": "./dist/index/index.common.js"
     },
     "./plugins/autoplay": {
+      "types": "./dist/autoplay/index.d.ts",
       "solid": "./dist/autoplay/autoplay.jsx",
       "import": "./dist/autoplay/index.module.js",
       "browser": "./dist/autoplay/index.module.js",
@@ -36,6 +38,7 @@
       "node": "./dist/autoplay/index.common.js"
     },
     "./plugins/adaptiveHeight": {
+      "types": "./dist/adaptiveHeight/index.d.ts",
       "solid": "./dist/adaptiveHeight/adaptiveHeight.jsx",
       "import": "./dist/adaptiveHeight/index.module.js",
       "browser": "./dist/adaptiveHeight/index.module.js",
@@ -43,6 +46,7 @@
       "node": "./dist/adaptiveHeight/index.common.js"
     },
     "./plugins/adaptiveWidth": {
+      "types": "./dist/adaptiveWidth/index.d.ts",
       "solid": "./dist/adaptiveWidth/adaptiveWidth.jsx",
       "import": "./dist/adaptiveWidth/index.module.js",
       "browser": "./dist/adaptiveWidth/index.module.js",


### PR DESCRIPTION
## Problem
When TypeScript's `moduleResolution` is set to a modern value like `NodeNext` or `Bundler`, compiling code that imports `solid-slider` currently gives the following error.
```
Could not find a declaration file for module 'solid-slider'. '/<path>/node_modules/solid-slider/dist/index/index.module.js' implicitly has an 'any' type.
  There are types at '/<path>/node_modules/solid-slider/dist/index/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-slider' library may need to update its package.json or typings.

2 import { createSlider } from 'solid-slider';
```
## Why does this happen?
`Bundler` or `NodeNext` tell TypeScript to read the `exports` field if it's present (falling back to `types` or `typesVersions`) to look up types. But that field contains no `types` condition in this package. Before `Bundler/NodeNext` (i.e. with option `Node/Node10` Typescript was looking up types from the `types` or `typesVersions` field), which works since the types are provided correctly in this case.

This PR adds the typings to the `exports` field in a `types` condition, which makes the type lookup work even under `moduleResolution: NodeNext/Bundler`

## Issue reproduction

In a package importing `solid-slider` run `tsc` with the `moduleResolution` set to `NodeNext` or `Bundler`.
