### PR TITLE
Prevent SliderDots from demanding children it doesn't use in Typescript

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   createSignal,
   FlowComponent,
+  Component,
   createEffect,
   For,
   Show,
@@ -129,7 +130,7 @@ export const SliderButton: FlowComponent<{
  * </SliderProvider>
  * ```
  */
-export const SliderDots: FlowComponent<{
+export const SliderDots: Component<{
   class?: string;
   classList?: { [k: string]: boolean | undefined };
   dotClass?: string;


### PR DESCRIPTION
`SliderDots` used the `FlowComponent` type, which is meant for components that strictly require children to function. `SliderDots` does not appear to use `props.children` anywhere, therefore it is more appropriate to use the Component type instead.